### PR TITLE
sync expense queue every time app opens

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -10,13 +10,20 @@ export default function LogoutScreen() {
   const { logout, authInfo } = useAuth();
 
   const userQuery = useUserInfo(authInfo);
-  const expenseQueueMutation = useClearExpenseQueue();
+  const clearExpenseQueueMutation = useClearExpenseQueue();
 
   const onLogoutPress = async () => {
     // invalidate all queries, clear the expense queue and logout
-    await expenseQueueMutation.mutateAsync();
-    await queryClient.invalidateQueries();
-    logout();
+    await queryClient.cancelQueries(); // cancel in-flight queries
+
+    try {
+      await clearExpenseQueueMutation.mutateAsync();
+    } catch (error) {
+      console.error("Failed to clear expense queue:", error);
+    } finally {
+      queryClient.clear(); // Clear all cached queries
+      logout();
+    }
   };
 
   return (

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from "@/components/context/AuthContext";
 import { queryClient } from "@/components/context/queryClient";
 import ExpenseQueue from "@/components/expenses/ExpenseQueue";
+import { useClearExpenseQueue } from "@/services/queries/expenses";
 import { useUserInfo } from "@/services/queries/users";
 import { Text, TouchableOpacity, View } from "react-native";
 import { ArrowRightOnRectangleIcon } from "react-native-heroicons/outline";
@@ -9,10 +10,12 @@ export default function LogoutScreen() {
   const { logout, authInfo } = useAuth();
 
   const userQuery = useUserInfo(authInfo);
+  const expenseQueueMutation = useClearExpenseQueue();
 
-  const onLogoutPress = () => {
-    // invalidate all queries and logout
-    queryClient.invalidateQueries();
+  const onLogoutPress = async () => {
+    // invalidate all queries, clear the expense queue and logout
+    await expenseQueueMutation.mutateAsync();
+    await queryClient.invalidateQueries();
     logout();
   };
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,10 @@
-import {
-  DefaultTheme,
-  ThemeProvider
-} from "@react-navigation/native";
+import { DefaultTheme, ThemeProvider } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import "react-native-reanimated";
 
+import { AutoSyncManager } from "@/components/AutoSyncManager";
 import { AuthProvider } from "@/components/context/AuthContext";
 import { ExpenseProvider } from "@/components/context/ExpenseContext";
 import { QueryContext } from "@/components/context/QueryContext";
@@ -77,6 +75,7 @@ export default function RootLayout() {
     <QueryContext>
       <AuthProvider>
         <ExpenseProvider>
+          <AutoSyncManager />
           <RootLayoutNav />
         </ExpenseProvider>
       </AuthProvider>

--- a/components/AutoSyncManager.tsx
+++ b/components/AutoSyncManager.tsx
@@ -1,0 +1,69 @@
+import { useAuth } from "@/components/context/AuthContext";
+import { queryClient } from "@/components/context/queryClient";
+import {
+  MUTATION_KEY_SYNC_EXPENSES,
+  useSyncExpenseQueue,
+} from "@/services/queries/expenseQueue";
+import { useEffect, useRef } from "react";
+import { AppState, AppStateStatus } from "react-native";
+
+/**
+ * AutoSyncManager - A component with no UI that automatically triggers
+ * expense queue sync when the app comes to foreground or starts up.
+ *
+ * Placed in the root layout to ensure it's always active when the user is authenticated.
+ */
+export function AutoSyncManager() {
+  const { isLoggedIn, isLoading } = useAuth();
+  const appState = useRef(AppState.currentState);
+  const syncExpenseQueueMutation = useSyncExpenseQueue();
+
+  // Store the mutation in a ref to avoid dependency issues
+  const syncMutationRef = useRef(syncExpenseQueueMutation);
+  syncMutationRef.current = syncExpenseQueueMutation;
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+
+    // Function to trigger sync if user is logged in and not already syncing
+    const triggerSyncIfNeeded = () => {
+      if (isLoggedIn && !isLoading) {
+        // Check if we aren't already syncing
+        const isSyncing =
+          queryClient.isMutating({
+            mutationKey: [MUTATION_KEY_SYNC_EXPENSES],
+          }) > 0;
+
+        if (!isSyncing) {
+          syncMutationRef.current.mutate();
+        }
+      }
+    };
+
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      // Trigger sync when app becomes active from background
+      if (
+        appState.current.match(/inactive|background/) &&
+        nextAppState === "active"
+      ) {
+        triggerSyncIfNeeded();
+      }
+      appState.current = nextAppState;
+    };
+
+    const subscription = AppState.addEventListener(
+      "change",
+      handleAppStateChange
+    );
+
+    // Trigger sync on initial mount if logged in (app startup)
+    if (!isLoading) {
+      triggerSyncIfNeeded();
+    }
+
+    return () => subscription?.remove();
+  }, [isLoggedIn, isLoading]);
+
+  // This component renders nothing
+  return null;
+}

--- a/services/queries/expenseQueue.ts
+++ b/services/queries/expenseQueue.ts
@@ -16,6 +16,7 @@ async function insertExpensesToApi(
     projectId: expense.projectId,
     rateId: expense.rateId,
     type: expense.type,
+    activity: expense.activity,
     description: expense.description,
     quantity: expense.quantity,
     price: expense.price,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic expense sync runs on app startup and when returning to the app, ensuring queued expenses are sent without manual action.
* **Improvements**
  * Sync only runs when signed in and avoids duplicate in-flight operations for reliability.
  * Expense submissions now include activity details, improving record accuracy and reporting.
  * Logout flow now clears the local expense queue before signing out.
* **Style**
  * Minor import formatting cleanup with no impact on functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->