### PR TITLE
401 error triggers logout

### DIFF
--- a/components/context/AuthContext.tsx
+++ b/components/context/AuthContext.tsx
@@ -12,7 +12,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
-import { registerOnUnauthorized } from "../../services/api";
+import { registerOnUnauthorized, unRegisterOnUnauthorized } from "../../services/api";
 
 interface AuthContextType {
   isLoggedIn: boolean;
@@ -59,6 +59,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
   registerOnUnauthorized(logout);
+
+  return () => {
+    unRegisterOnUnauthorized(logout);
+  };
 }, [logout]);
 
   console.log("AuthProvider rendered, isLoggedIn:", isLoggedIn);

--- a/components/context/AuthContext.tsx
+++ b/components/context/AuthContext.tsx
@@ -12,6 +12,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { registerOnUnauthorized } from "../../services/api";
 
 interface AuthContextType {
   isLoggedIn: boolean;
@@ -55,6 +56,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setIsLoading(false);
     });
   }, []);
+
+  useEffect(() => {
+  registerOnUnauthorized(logout);
+}, [logout]);
 
   console.log("AuthProvider rendered, isLoggedIn:", isLoggedIn);
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -6,6 +6,12 @@ export function registerOnUnauthorized(handler: () => void | Promise<void>) {
   onUnauthorized = handler;
 }
 
+export function unRegisterOnUnauthorized(handler: () => void | Promise<void>) {
+  if (onUnauthorized === handler) {
+    onUnauthorized = null;
+  }
+}
+
 /**
  * Ensures we have valid auth info, either from the provided parameter or local storage
  */

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,6 +1,11 @@
 import { getCurrentTeamAuthInfo, TeamAuthInfo } from "@/lib/auth";
 import { logger } from "@/lib/logger";
 
+let onUnauthorized: (() => void | Promise<void>) | null = null;
+export function registerOnUnauthorized(handler: () => void | Promise<void>) {
+  onUnauthorized = handler;
+}
+
 /**
  * Ensures we have valid auth info, either from the provided parameter or local storage
  */
@@ -44,7 +49,11 @@ export async function fetchFromApi<T>(
     headers,
   });
 
-  if (!res.ok) {
+    if (!res.ok) {
+    if (res.status === 401) {
+      await onUnauthorized?.()
+      alert("Session expired. Please log in again.");
+    }
     const body = await res.text().catch(() => ""); // try to get body text, ignore errors
 
     const err = new Error(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide automatic logout when an unauthorized API response occurs, with consistent "session expired" prompting to sign in again.
  * The authentication provider now registers/unregisters global unauthorized handling so the behavior is active while you're signed in.

* **Bug Fixes**
  * Reduces confusing errors by promptly ending invalid sessions and guiding reauthentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->