### PR TITLE
readme on physical device testing + build cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Using the simulator is fine for most things, but if you want to test the camera,
 2. Open Xcode and go to `Window > Devices and Simulators`.
 3. Device should show up in the list, you might need to click a few buttons on your phone to "trust" the computer.
 4. Follow instructions in Xcode to get your phone setup, I needed to go turn on developer mode on the phone.
-5. In XCode signin with the UCD Apple ID and select the UCD team for signing. I opened the ios/Harvest.xcodeproj file in Xcode to do this, then in the "Signing & Capabilities" tab I selected the UCD team. May not be necessary if you are already signed in.
+5. In XCode signin with the UCD Apple ID and select the UCD team for signing. I opened the ios/harvestmobile.xcodeproj file in Xcode to do this, then in the "Signing & Capabilities" tab I selected the UCD team. May not be necessary if you are already signed in.
 6. Run `npx expo run:ios --device` and choose your device from the list, it should install the app on your phone. You only need to do this when native code is changed (new depdendency, icons, etc). You should be able to do this wireless from the same WiFi, but USB always works as a fallback.
 
 ### Running the app on your phone

--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@
 
 More info about setup [using ios Simulator plus local build](https://docs.expo.dev/get-started/set-up-your-environment/?platform=ios&device=simulated&mode=development-build&buildEnv=local).
 
+## Physical Device Setup
+
+Using the simulator is fine for most things, but if you want to test the camera, airplane mode, or push notifications which we might have some day, you'll need to run on a physical device.
+
+### Initial Setup (one-time)
+
+1. Connect your iPhone to your Mac with a USB cable.
+2. Open Xcode and go to `Window > Devices and Simulators`.
+3. Device should show up in the list, you might need to click a few buttons on your phone to "trust" the computer.
+4. Follow instructions in Xcode to get your phone setup, I needed to go turn on developer mode on the phone.
+5. In XCode signin with the UCD Apple ID and select the UCD team for signing. I opened the ios/Harvest.xcodeproj file in Xcode to do this, then in the "Signing & Capabilities" tab I selected the UCD team. May not be necessary if you are already signed in.
+6. Run `npx expo run:ios --device` and choose your device from the list, it should install the app on your phone. You only need to do this when native code is changed (new depdendency, icons, etc). You should be able to do this wireless from the same WiFi, but USB always works as a fallback.
+
+### Running the app on your phone
+
+`npx expo start --dev-client` and then open the app on your phone. You can use the QR code in the terminal to hook up to the dev server (probably needed first time only).
+
+Note: Shake the phone to open the dev menu for handy stuff like reloading the app.
+
 ## Testing
 
 We don't have any testing setup yet. There are some placeholders in the package.json and azure-pipelines.yml for running tests, but no actual tests yet.

--- a/app.json
+++ b/app.json
@@ -68,7 +68,10 @@
       ]
     ],
     "experiments": {
-      "typedRoutes": true
+      "typedRoutes": true,
+      "buildCacheProvider": {
+        "plugin": "expo-build-disk-cache"
+      }
     },
     "extra": {
       "router": {},

--- a/ios/harvestmobile.xcodeproj/project.pbxproj
+++ b/ios/harvestmobile.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		716DF5C798C7255B4419A866 /* Pods-harvestmobile.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-harvestmobile.release.xcconfig"; path = "Target Support Files/Pods-harvestmobile/Pods-harvestmobile.release.xcconfig"; sourceTree = "<group>"; };
 		96EACEEA96CB0212C1F45AF3 /* Pods-harvestmobile.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-harvestmobile.debug.xcconfig"; path = "Target Support Files/Pods-harvestmobile/Pods-harvestmobile.debug.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = harvestmobile/SplashScreen.storyboard; sourceTree = "<group>"; };
-		AE94D27E5CAECE0434CAE8CC /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = harvestmobile/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		AE94D27E5CAECE0434CAE8CC /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = harvestmobile/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		BA03F76A98CCD37431D4C308 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-harvestmobile/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -111,7 +111,6 @@
 				96EACEEA96CB0212C1F45AF3 /* Pods-harvestmobile.debug.xcconfig */,
 				716DF5C798C7255B4419A866 /* Pods-harvestmobile.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -367,6 +366,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = harvestmobile/harvestmobile.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = NGYSGB754K;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -403,6 +403,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = harvestmobile/harvestmobile.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = NGYSGB754K;
 				INFOPLIST_FILE = harvestmobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -480,10 +481,7 @@
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -538,10 +536,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@types/react": "~19.0.10",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
+        "expo-build-disk-cache": "^0.7.0",
         "typescript": "~5.8.3"
       }
     },
@@ -6636,6 +6637,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -7393,6 +7404,71 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-build-disk-cache": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/expo-build-disk-cache/-/expo-build-disk-cache-0.7.0.tgz",
+      "integrity": "sha512-I3ml8YwdUFbpF5+/ipYFtRnuyXMndk8qUCQgvGEODaDWPeFMrbD8md2dQDrcbcGqRNb+vIxWd32NS/1A80nsUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cosmiconfig": "^9.0.0",
+        "env-paths": "^2.2.1",
+        "zod": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@expo/cli": "*",
+        "@expo/config": "*"
+      }
+    },
+    "node_modules/expo-build-disk-cache/node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-build-disk-cache/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/expo-camera": {
@@ -14770,6 +14846,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
+    "expo-build-disk-cache": "^0.7.0",
     "typescript": "~5.8.3"
   },
   "jest-junit": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added “Physical Device Setup” to README with initial device connection, Xcode trust/signing steps, and instructions to run on a device.
  - Added “Running the app on your phone” with dev server usage and dev menu note.

- Chores
  - Enabled build caching via Expo experiments for faster builds.
  - Added expo-build-disk-cache dependency.
  - Updated iOS project settings (team configuration and linker flags) for consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->