### PR TITLE
Configures build cache directory

### DIFF
--- a/app.json
+++ b/app.json
@@ -73,7 +73,10 @@
     "experiments": {
       "typedRoutes": true,
       "buildCacheProvider": {
-        "plugin": "expo-build-disk-cache"
+        "plugin": "expo-build-disk-cache",
+        "options": {
+          "cacheDir": "node_modules/.expo-build-disk-cache"
+        }
       }
     },
     "extra": {


### PR DESCRIPTION
build cache was causing issues, i think because clean my mac deletes the temp directory randomly?  I moved it to node_modules which should be safe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured a dedicated build cache directory for the project’s build process.
  * Improves build stability and may reduce rebuild times and local cache conflicts.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->