### PR TITLE
wait until app ready to show main content

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "UCD Harvest",
     "slug": "harvest-mobile",
-    "version": "1.1.2",
+    "version": "1.1.4",
     "orientation": "portrait",
     "icon": "./assets/images/app-icon.png",
     "scheme": "harvestmobile",


### PR DESCRIPTION
prevents a flash of no content as db and auth spin up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced app startup experience with improved splash screen handling during authentication verification

* **Chores**
  * Version bumped to 1.1.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->