### PR TITLE
Cap expense markup at $1,000 and clarify UI

### DIFF
--- a/app/addExpenses.tsx
+++ b/app/addExpenses.tsx
@@ -187,9 +187,13 @@ export default function AddExpenseScreen() {
                       {item.rate?.description}
                     </Text>
                     <Text className="text-base text-primaryfont/70 font-semibold">
-                      {item.quantity} {item.rate?.unit} @ ${item.price}{" "}
-                      {item.markup ? tx("common.markupSuffix") : ""}
+                      {item.quantity} {item.rate?.unit} @ ${item.price}
                     </Text>
+                    {item.markup && (
+                      <Text className="mt-0.5 text-xs font-semibold uppercase tracking-tight text-primaryfont/55">
+                        {tx("common.markupSummary")}
+                      </Text>
+                    )}
                   </View>
                 </View>
 

--- a/app/expenseDetails.tsx
+++ b/app/expenseDetails.tsx
@@ -16,7 +16,11 @@ import {
 import { ExclamationTriangleIcon } from "react-native-heroicons/solid";
 
 import { useExpenses } from "@/components/context/ExpenseContext";
-import { createExpenseWithUniqueId, Rate } from "@/lib/expense";
+import {
+  calculateExpenseTotal,
+  createExpenseWithUniqueId,
+  Rate,
+} from "@/lib/expense";
 import { tx } from "@/lib/i18n";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -49,7 +53,6 @@ export default function ExpenseDetailsScreen() {
   const [quantity, setQuantity] = useState("");
   const [description, setDescription] = useState("");
   const [markup, setMarkup] = useState(false);
-  const MARKUP_MULTIPLIER = 1.2;
 
   const handleQuantityChange = (value: string) => {
     // Allow empty string for clearing the input
@@ -149,8 +152,11 @@ export default function ExpenseDetailsScreen() {
 
   const getTotalCost = () => {
     const numericQuantity = parseFloat(quantity) || 0;
-    const baseTotal = numericQuantity * (rate?.price || 0);
-    const total = isMarkupApplied ? baseTotal * MARKUP_MULTIPLIER : baseTotal;
+    const total = calculateExpenseTotal(
+      rate?.price || 0,
+      numericQuantity,
+      isMarkupApplied
+    );
     return total.toFixed(2);
   };
 
@@ -268,29 +274,36 @@ export default function ExpenseDetailsScreen() {
 
                 {/* Markup Toggle (only for other) */}
                 {showMarkupInput && (
-                  <TouchableOpacity
-                    activeOpacity={0.8}
-                    onPress={() => setMarkup((v) => !v)}
-                    className="flex-row items-center"
-                    accessibilityRole="checkbox"
-                    accessibilityLabel={tx(
-                      "expenseDetails.markupAccessibilityLabel"
-                    )}
-                    accessibilityState={{ checked: markup }}
-                  >
-                    <View
-                      className={`h-6 w-6 items-center justify-center rounded-md border border-primaryborder ${
-                        markup ? "bg-harvest" : "bg-white"
-                      }`}
-                    >
-                      {markup && (
-                        <Text className="text-white text-sm font-bold">✓</Text>
+                  <View className="mb-4 rounded-2xl border border-primaryborder bg-white px-4 py-3">
+                    <TouchableOpacity
+                      activeOpacity={0.8}
+                      onPress={() => setMarkup((v) => !v)}
+                      className="flex-row items-start"
+                      accessibilityRole="checkbox"
+                      accessibilityLabel={tx(
+                        "expenseDetails.markupAccessibilityLabel"
                       )}
-                    </View>
-                    <Text className="ml-3 text-base font-semibold text-primaryfont">
-                      {tx("expenseDetails.markupLabel")}
-                    </Text>
-                  </TouchableOpacity>
+                      accessibilityState={{ checked: markup }}
+                    >
+                      <View
+                        className={`mt-0.5 h-6 w-6 items-center justify-center rounded-md border border-primaryborder ${
+                          markup ? "bg-harvest" : "bg-white"
+                        }`}
+                      >
+                        {markup && (
+                          <Text className="text-white text-sm font-bold">✓</Text>
+                        )}
+                      </View>
+                      <View className="ml-3 flex-1">
+                        <Text className="text-base font-semibold text-primaryfont">
+                          {tx("expenseDetails.markupLabel")}
+                        </Text>
+                        <Text className="mt-1 text-sm leading-5 text-primaryfont/65">
+                          {tx("expenseDetails.markupInfo")}
+                        </Text>
+                      </View>
+                    </TouchableOpacity>
+                  </View>
                 )}
               </View>
             </View>
@@ -316,8 +329,12 @@ export default function ExpenseDetailsScreen() {
             <View>
               <Text className="text-base font-semibold text-primaryfont/40 text-start">
                 {quantity || "0"} {rate.unit} × ${rate.price}
-                {isMarkupApplied ? tx("common.markupSuffix") : ""}
               </Text>
+              {isMarkupApplied && (
+                <Text className="mt-1 text-xs font-semibold uppercase tracking-tight text-primaryfont/55">
+                  {tx("common.markupSummary")}
+                </Text>
+              )}
               <Text className="text-lg font-extrabold text-harvest">
                 ${getTotalCost()}
               </Text>

--- a/app/expenseDetails.tsx
+++ b/app/expenseDetails.tsx
@@ -256,17 +256,19 @@ export default function ExpenseDetailsScreen() {
 
                 {/* Description Input */}
                 {showDescriptionInput && (
-                  <View className="mb-6">
+                  <View className="mb-4">
                     <Text className="text-sm font-semibold text-primaryfont/60 tracking-tight mb-2">
                       {tx("expenseDetails.descriptionLabel")}
                     </Text>
                     <TextInput
-                      className="bg-white rounded-lg p-4 text-base border border-primaryborder min-h-[80px]"
+                      className="bg-white rounded-lg p-4 text-base border border-primaryborder"
+                      style={{ height: 80 }}
                       value={description}
                       onChangeText={setDescription}
                       placeholder={tx("expenseDetails.descriptionPlaceholder")}
                       placeholderTextColor="#999"
                       multiline
+                      scrollEnabled
                       textAlignVertical="top"
                     />
                   </View>
@@ -274,36 +276,32 @@ export default function ExpenseDetailsScreen() {
 
                 {/* Markup Toggle (only for other) */}
                 {showMarkupInput && (
-                  <View className="mb-4 rounded-2xl border border-primaryborder bg-white px-4 py-3">
-                    <TouchableOpacity
-                      activeOpacity={0.8}
-                      onPress={() => setMarkup((v) => !v)}
-                      className="flex-row items-start"
-                      accessibilityRole="checkbox"
-                      accessibilityLabel={tx(
-                        "expenseDetails.markupAccessibilityLabel"
-                      )}
-                      accessibilityState={{ checked: markup }}
+                  <TouchableOpacity
+                    activeOpacity={0.8}
+                    onPress={() => setMarkup((v) => !v)}
+                    className="flex-row items-center mb-4"
+                    accessibilityRole="checkbox"
+                    accessibilityLabel={tx(
+                      "expenseDetails.markupAccessibilityLabel"
+                    )}
+                    accessibilityState={{ checked: markup }}
+                  >
+                    <View
+                      className={`h-6 w-6 items-center justify-center rounded-md border border-primaryborder ${
+                        markup ? "bg-harvest" : "bg-white"
+                      }`}
                     >
-                      <View
-                        className={`mt-0.5 h-6 w-6 items-center justify-center rounded-md border border-primaryborder ${
-                          markup ? "bg-harvest" : "bg-white"
-                        }`}
-                      >
-                        {markup && (
-                          <Text className="text-white text-sm font-bold">✓</Text>
-                        )}
-                      </View>
-                      <View className="ml-3 flex-1">
-                        <Text className="text-base font-semibold text-primaryfont">
-                          {tx("expenseDetails.markupLabel")}
-                        </Text>
-                        <Text className="mt-1 text-sm leading-5 text-primaryfont/65">
-                          {tx("expenseDetails.markupInfo")}
-                        </Text>
-                      </View>
-                    </TouchableOpacity>
-                  </View>
+                      {markup && (
+                        <Text className="text-white text-sm font-bold">✓</Text>
+                      )}
+                    </View>
+                    <Text className="ml-3 text-base font-semibold text-primaryfont">
+                      {tx("expenseDetails.markupLabel")}
+                    </Text>
+                    <Text className="ml-2 text-sm text-primaryfont/65">
+                      {tx("expenseDetails.markupInfo")}
+                    </Text>
+                  </TouchableOpacity>
                 )}
               </View>
             </View>
@@ -328,20 +326,15 @@ export default function ExpenseDetailsScreen() {
           <View className="px-4 py-2 flex-row items-center justify-between mb-5">
             <View>
               <Text className="text-base font-semibold text-primaryfont/40 text-start">
-                {quantity || "0"} {rate.unit} × ${rate.price}
+                {quantity || "0"} {rate.unit} × ${rate.price}{isMarkupApplied ? ` ${tx("common.markupSummary")}` : ""}
               </Text>
-              {isMarkupApplied && (
-                <Text className="mt-1 text-xs font-semibold uppercase tracking-tight text-primaryfont/55">
-                  {tx("common.markupSummary")}
-                </Text>
-              )}
               <Text className="text-lg font-extrabold text-harvest">
                 ${getTotalCost()}
               </Text>
             </View>
 
             <TouchableOpacity
-              className="harvest-button w-[55%]"
+              className="harvest-button w-[45%]"
               onPress={handleConfirm}
             >
               <Text className="harvest-button-text">

--- a/components/expenses/ExpenseQueue.tsx
+++ b/components/expenses/ExpenseQueue.tsx
@@ -1,5 +1,5 @@
 import { queryClient } from "@/components/context/queryClient";
-import { QueuedExpense } from "@/lib/expense";
+import { calculateExpenseTotal, QueuedExpense } from "@/lib/expense";
 import { tx } from "@/lib/i18n";
 import {
   MUTATION_KEY_SYNC_EXPENSES,
@@ -207,7 +207,13 @@ export default function ExpenseQueue({ className }: ExpenseQueueProps) {
                     {tx("components.expenseQueue.totalLabel")}
                   </Text>
                   <Text className="text-sm font-medium text-gray-900">
-                    {formatPrice(expense.price * expense.quantity)}
+                    {formatPrice(
+                      calculateExpenseTotal(
+                        expense.price,
+                        expense.quantity,
+                        expense.markup
+                      )
+                    )}
                   </Text>
                 </View>
 

--- a/lib/expense.ts
+++ b/lib/expense.ts
@@ -53,6 +53,23 @@ export type QueuedExpense = Expense & {
   errorMessage?: string; // error message if sync failed
 };
 
+export const MARKUP_RATE = 0.2;
+export const MARKUP_CAP = 1000;
+
+export function calculateExpenseTotal(
+  price: number,
+  quantity: number,
+  markup: boolean
+): number {
+  const baseTotal = price * quantity;
+
+  if (!markup) {
+    return baseTotal;
+  }
+
+  return baseTotal + Math.min(baseTotal, MARKUP_CAP) * MARKUP_RATE;
+}
+
 export function getExpenseUniqueId(): string {
   // Generate a UUID v4 using expo-crypto
   return Crypto.randomUUID();

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -6,7 +6,7 @@ const translations = {
     common: {
       ok: "OK",
       tryAgain: "Try Again",
-      markupSummary: "20% markup on first $1,000",
+      markupSummary: "+markup",
     },
     auth: {
       welcomeToHarvest: "Welcome to Harvest",
@@ -237,7 +237,7 @@ const translations = {
     common: {
       ok: "Aceptar",
       tryAgain: "Reintentar",
-      markupSummary: "Recargo del 20% sobre los primeros $1,000",
+      markupSummary: "+recargo",
     },
     auth: {
       welcomeToHarvest: "Bienvenido a Harvest",
@@ -450,7 +450,8 @@ const translations = {
         title: "Gastos recientes",
         subtitle: "Mostrando gastos enviados en los últimos 7 días.",
         loadingRecentExpenses: "Cargando gastos recientes...",
-        failedToLoadRecentExpenses: "No se pudieron cargar los gastos recientes.",
+        failedToLoadRecentExpenses:
+          "No se pudieron cargar los gastos recientes.",
         statusApproved: "aprobado",
         statusSubmitted: "enviado",
         noRecentExpenses: "Aún no hay gastos recientes",

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -6,7 +6,7 @@ const translations = {
     common: {
       ok: "OK",
       tryAgain: "Try Again",
-      markupSuffix: " (+20%)",
+      markupSummary: "20% markup on first $1,000",
     },
     auth: {
       welcomeToHarvest: "Welcome to Harvest",
@@ -114,6 +114,7 @@ const translations = {
       descriptionPlaceholder: "Enter description (required)",
       markupAccessibilityLabel: "Markup",
       markupLabel: "Markup",
+      markupInfo: "Adds 20% to the first $1,000 only.",
       addExpenseButton: "Add Expense",
     },
     qrScan: {
@@ -236,7 +237,7 @@ const translations = {
     common: {
       ok: "Aceptar",
       tryAgain: "Reintentar",
-      markupSuffix: " (+20%)",
+      markupSummary: "Recargo del 20% sobre los primeros $1,000",
     },
     auth: {
       welcomeToHarvest: "Bienvenido a Harvest",
@@ -346,6 +347,7 @@ const translations = {
       descriptionPlaceholder: "Ingresa una descripción (requerida)",
       markupAccessibilityLabel: "Recargo",
       markupLabel: "Recargo",
+      markupInfo: "Agrega 20% solo a los primeros $1,000.",
       addExpenseButton: "Agregar gasto",
     },
     qrScan: {


### PR DESCRIPTION
The 20% markup now applies only to the first $1,000 of an expense's base total. This change centralizes the calculation logic in a new utility function and updates all relevant screens to clearly explain the markup rule to users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Markup now displays on its own styled line beneath the price for clarity.
  * Markup toggle layout and spacing updated; confirm button and description input sizing adjusted.

* **Bug Fixes**
  * Expense totals now calculate consistently across screens when markup is enabled.

* **Documentation**
  * Clarified copy: "20% markup on the first $1,000" and added brief markup info text in locale strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->